### PR TITLE
fix for #132

### DIFF
--- a/profile/ekstep/rootfs_overlay/etc/nginx/sites-enabled/opencdn_nginx
+++ b/profile/ekstep/rootfs_overlay/etc/nginx/sites-enabled/opencdn_nginx
@@ -57,7 +57,7 @@ server {
 
 	location / {
                 #proxy_pass http://127.0.0.1:8008;
-				try_files $uri $uri/ @ekstep;
+				try_files $uri $uri/ /index.html;
 	}
 }
 server {


### PR DESCRIPTION
Refreshing the page or opening new tab was throwing an error.
Fixing routing issues from nginx.