### PR TITLE
Fixes issue OP-58

### DIFF
--- a/devmgmtui/src/components/cloud/CloudDownload.js
+++ b/devmgmtui/src/components/cloud/CloudDownload.js
@@ -176,6 +176,7 @@ class CloudDownload extends Component {
 				console.log(err);
 				
 				alert('Trouble fetching content from Diksha server.');
+				this.props.clearCurrentContent();
 			}
 		});
 	}
@@ -320,8 +321,6 @@ class CloudDownload extends Component {
 
 	componentDidMount() {
 		document.title = 'Cloud Download';
-		
-		this.handleSearchClick();
 		this.downloadManager.connect();
 	}
 	

--- a/devmgmtui/src/components/cloud/ContentArea.js
+++ b/devmgmtui/src/components/cloud/ContentArea.js
@@ -148,7 +148,7 @@ function renderTable(content, handleDownload) {
 }
 
 function renderNoResultsFound(query) {
-	const placeholderText = !query ? "Nothing to show here" : `No results found for "${query}"`;
+	const placeholderText = query ? `No results found for "${query}"` : "Nothing to show here";
 
 	return (
 		<div style={styles.noResults}>

--- a/devmgmtui/src/components/cloud/ContentArea.js
+++ b/devmgmtui/src/components/cloud/ContentArea.js
@@ -148,10 +148,12 @@ function renderTable(content, handleDownload) {
 }
 
 function renderNoResultsFound(query) {
+	const placeholderText = !query ? "Nothing to show here" : `No results found for "${query}"`;
+
 	return (
 		<div style={styles.noResults}>
 			<Icon name='search' size='massive'/>
-			<h2>No results found for "{query}"</h2>
+			<h2>{placeholderText}</h2>
 		</div>
 	);
 }

--- a/devmgmtui/src/components/cloud/Downloads.js
+++ b/devmgmtui/src/components/cloud/Downloads.js
@@ -80,7 +80,7 @@ function renderNoDownloads() {
 	return (
 		<div style={styles.noDownloads}>
 			<Icon name='download' size='huge' />
-			<h2>No downloads in progress.</h2>
+			<h2>No downloads in progress</h2>
 		</div>
 	);
 }


### PR DESCRIPTION
Bug Number: [OP-58](https://project-sunbird.atlassian.net/browse/OP-58)
Issue: Cloud search keeps showing the loading spinner even after the search has failed
RCA: When the search got triggered, a state variable got updated to indicate the search has begun which caused the spinner to get rendered. In case of an error the state variable was not being reset, thus causing the issue.
Fix: Reset the state variable in case of a failure.

On error:
![screenshot from 2019-02-08 15-57-45](https://user-images.githubusercontent.com/22426390/52472901-82360300-2bba-11e9-8592-b8b4e9360658.png)

On clicking OK:
![screenshot from 2019-02-08 15-57-55](https://user-images.githubusercontent.com/22426390/52472899-82360300-2bba-11e9-9f64-5bcfcc01369e.png)


