### PR TITLE
Fixes issue OP-72

### DIFF
--- a/devmgmtui/src/components/cloud/DownloadManager.js
+++ b/devmgmtui/src/components/cloud/DownloadManager.js
@@ -12,7 +12,7 @@ export default class DownloadManager {
 
 		this.aria2.on('close', () => {
 			console.log('Disconnected from the download manager.');
-			this.connected = false;	
+			this.connected = false;
 			this.connect();
 		});
 
@@ -23,16 +23,15 @@ export default class DownloadManager {
 	}
 
 	async connect() {
-		if (!this.connected) {
+		if (this.connected) {
+			console.log('Already connected.');
+		} else {
 			try {
 				await this.aria2.open();
-				console.log('Connected to aria2.');
 			} catch(err) {
-				console.log('Error occured while connecting to aria2.');
+				console.log('Error occured while connecting to the download manager.');
 				console.log({ err });
 			}
-		} else {
-			console.log('Already connected.');
 		}
 	}
 
@@ -52,10 +51,9 @@ export default class DownloadManager {
 				return -1;
 			}
 		} else if (retries == 0) {
-			console.log('Couldn\'t connect to aria2.');
+			console.log('Couldn\'t connect to the download manager.');
 			return -1;
 		} else {
-			console.log('Connection not established. Re-establishing connection...');
 			await this.connect();
 			return this.downloadData(uri, ecarName, --retries);
 		}

--- a/devmgmtui/src/components/cloud/DownloadManager.js
+++ b/devmgmtui/src/components/cloud/DownloadManager.js
@@ -11,10 +11,13 @@ export default class DownloadManager {
 		this.aria2 = aria2;
 
 		this.aria2.on('close', () => {
+			console.log('Disconnected from the download manager.');
 			this.connected = false;	
+			this.connect();
 		});
 
 		this.aria2.on('open', () => {
+			console.log('Connected to the download manager.');
 			this.connected = true;
 		});
 	}


### PR DESCRIPTION
Bug Number: [OP-72](https://project-sunbird.atlassian.net/browse/OP-72)
Issue: Cloud download fails and keeps on loading when some big files are downloaded
RCA: In case of big files (where download takes >60s), the web socket connection to aria2 was timing out before the file got downloaded entirely. This caused the front-end to not receive any events from aria2 over WS  when the download finished, thus the download card kept loading.
Fix: Reconnect every time the WS connection closes.