### PR TITLE
Fixes issue OP-57

### DIFF
--- a/devmgmtui/src/components/cloud/CloudDownload.js
+++ b/devmgmtui/src/components/cloud/CloudDownload.js
@@ -343,7 +343,7 @@ class CloudDownload extends Component {
 				const file = files[0];
 				const path = file.path;
 
-				const name = path.substring(path.lastIndexOf('/') + 1).replace(/.ecar/, '');;
+				const name = path.substring(path.lastIndexOf('/') + 1).replace(/.ecar/, '');
 				const id = name.substring(0, name.lastIndexOf('_'));
 				const ver = name.substring(name.lastIndexOf('_'), name.lastIndexOf('.'));
 				const size = this.formatBytes(totalLength);

--- a/devmgmtui/src/components/cloud/CloudDownload.js
+++ b/devmgmtui/src/components/cloud/CloudDownload.js
@@ -176,7 +176,7 @@ class CloudDownload extends Component {
 		this.props.searchContent(queryString, limit, offset, (err) => {
 			if (err) {
 				console.log(err);
-				
+
 				alert('Unable to connect to Cloud Media server. Check your internet connection and retry.');
 				this.props.clearCurrentContent();
 			}
@@ -327,42 +327,47 @@ class CloudDownload extends Component {
 
 		let consolidatedDownloadsList = [];
 		let downloadedFiles = [];
-
 		let [activeDownloads, waitingDownloads] = await Promise.all([
 			this.downloadManager.getActiveDownloads(),
 			this.downloadManager.getWaitingDownloads(0, parseInt(globalStat.numWaiting))
 		]);
 
-		const parseDownloadList = downloads => {
-			downloads.map(download => {
-			const {
-				gid,
-				files,
-				totalLength
-			} = download;
+		const parseDownloadList = (downloads, status) => {
+			return downloads.map(download => {
+				const {
+					gid,
+					files,
+					totalLength
+				} = download;
 
-			const file = files[0];
-			const path = file.path;
+				const file = files[0];
+				const path = file.path;
 
-			const name = path.substring(path.lastIndexOf('/')+1).replace(/.ecar/, '');;
-			const id = name.substring(0, name.lastIndexOf('_'));
-			const ver = name.substring(name.lastIndexOf('_'), name.lastIndexOf('.'));
-			const size = this.formatBytes(totalLength);
-			const uri = file.uris[0].uri;
+				const name = path.substring(path.lastIndexOf('/') + 1).replace(/.ecar/, '');;
+				const id = name.substring(0, name.lastIndexOf('_'));
+				const ver = name.substring(name.lastIndexOf('_'), name.lastIndexOf('.'));
+				const size = this.formatBytes(totalLength);
+				const uri = file.uris[0].uri;
 
-			return ({ guid: gid, name, id, ver, size, uri, isRoot: false, status: 'ongoing' });
-		});
-		}
+				return ({ guid: gid, name, id, ver, size, uri, isRoot: false, status });
+			});
+		};
 
-		activeDownloads = parseDownloadList(activeDownloads);
-		waitingDownloads = parseDownloadList(waitingDownloads);
+		const getUniqueDownloadList = (downloads, key) => {
+			let seen = {};
+			return downloads.filter(item => {
+				const k = item[key];
+				return seen.hasOwnProperty(k) ? false : (seen[k] = true);
+			});
+		};
+
+		activeDownloads = parseDownloadList(activeDownloads, 'ongoing');
+		waitingDownloads = parseDownloadList(waitingDownloads, 'waiting');
 
 		axios.get(`${BASE_URL}/file/open`, { params: { path: this.state.downloadPath } })
 			.then(response => {
-				downloadedFiles = response.data.children;
-
-				downloadedFiles = downloadedFiles
-					.filter(item => item.type === 'file')
+				downloadedFiles = response.data.children
+					.filter(item => item.type === 'file' && item.name.endsWith('.ecar'))
 					.map(item => {
 						let {
 							name,
@@ -376,16 +381,14 @@ class CloudDownload extends Component {
 
 						return ({ name, size, id, ver, isRoot: false, status: 'done' });
 					});
-					
-					downloadedFiles.forEach(item => this.addNewDownload(item));
+
+				consolidatedDownloadsList = [].concat(activeDownloads, waitingDownloads, downloadedFiles);
+				getUniqueDownloadList(consolidatedDownloadsList, 'id').forEach(download => this.addNewDownload(download));
 			})
 			.catch(error => {
 				console.log("Error fetching downloaded files.");
 				console.log(error);
 			});
-
-		consolidatedDownloadsList = consolidatedDownloadsList.concat(activeDownloads, waitingDownloads);
-		consolidatedDownloadsList.forEach(download => this.addNewDownload(download));
 	}
 
 	componentDidMount() {

--- a/devmgmtui/src/components/cloud/DownloadManager.js
+++ b/devmgmtui/src/components/cloud/DownloadManager.js
@@ -80,4 +80,19 @@ export default class DownloadManager {
 		const details = await this.aria2.call('tellStatus', guid);
 		return details;
 	}
+
+	async getActiveDownloads() {
+		const details = await this.aria2.call('tellActive');
+		return details;
+	}
+
+	async getWaitingDownloads(offset, num) {
+		const details = await this.aria2.call('tellWaiting', offset, num);
+		return details;
+	}
+
+	async getGlobalStat() {
+		const details = await this.aria2.call('getGlobalStat');
+		return details;
+	}
 }

--- a/devmgmtui/src/components/cloud/Downloads.js
+++ b/devmgmtui/src/components/cloud/Downloads.js
@@ -12,6 +12,9 @@ const styles = {
 	downloadCard: {
 		width: '100%'
 	},
+	downloadCardSubheading: {
+		color: 'grey'
+	},
 	downloadCardList: {
 		paddingBottom: '32px'
 	},
@@ -37,6 +40,7 @@ function DownloadCard(props) {
 	switch(status) {
 		case 'ongoing': cardStatusIndicator = <Loader active />; break;
 		case 'done': cardStatusIndicator = <Icon name='check circle' size='big' color='green' />; break;
+		case 'waiting': cardStatusIndicator = <Icon name='pause circle' size='big' color='yellow' />; break;
 		case 'failed': cardStatusIndicator = <Icon name='warning circle' size='big' color='red' />; break;
 	}
 
@@ -44,10 +48,10 @@ function DownloadCard(props) {
 		<Segment compact style={styles.downloadCard}>
 			<Grid columns={2}>
 				<Grid.Column width={13} stretched>
-					<Header as='h2' floated='left'>
+					<Header as='h2' floated='left' size='medium'>
 						<Header.Content>
-							{name}
-							<Header.Subheader>Size {size}</Header.Subheader>
+								{name}
+							<Header.Subheader style={styles.downloadCardSubheading}>Size: {size}</Header.Subheader>
 						</Header.Content>
 					</Header>
 				</Grid.Column>


### PR DESCRIPTION
Bug Number: [OP-57](https://project-sunbird.atlassian.net/browse/OP-57)
Issue: While download is in progress, if User click on browser refresh button, download should not get affected.
RCA: The state of the download list was being managed in Redux store, which got reset every time the page was loaded. This was causing the downloads to disappear.
Fix: Fetch the active downloads and completed downloads from the backend every time the cloud search component is mounted and update the state.

Following are some screenshots to demonstrate the new workflow,

Intial page showing all the existing ecar files under `/home/admin/diksha`:
![screenshot_2019-02-15 cloud download](https://user-images.githubusercontent.com/22426390/52845171-6d162280-312c-11e9-8b81-235fe8734c6b.png)
When a search is performed and file is added for downloading:
![screenshot_2019-02-15 cloud download 1](https://user-images.githubusercontent.com/22426390/52845182-77382100-312c-11e9-97f1-de004fc27c9f.png)
On refreshing or closing and opening a tab:
![screenshot_2019-02-15 cloud download 2](https://user-images.githubusercontent.com/22426390/52845181-77382100-312c-11e9-8a8b-842ce7ffb1c6.png)
Finally when the file has been downloaded:
![screenshot_2019-02-15 cloud download 3](https://user-images.githubusercontent.com/22426390/52845179-77382100-312c-11e9-9e2e-d3e8137d60da.png)

