### PR TITLE
Addresses issue OP-93 by showing an alert on the attempt to upload empty folder(s)

### DIFF
--- a/devmgmtui/src/components/filemgmt/FileUploadComponent.js
+++ b/devmgmtui/src/components/filemgmt/FileUploadComponent.js
@@ -17,12 +17,16 @@ class FileUploadComponent extends Component {
     }
   }
 
-  handleFileInputChange(fileList)  {
-    let files = this.props.filemgmt.uploadableFiles;
-    for (let i = 0; i < fileList.length; i++) {
-      files.push(fileList[i]);
+  handleFileInputChange(fileList, type)  {
+    if(type == "folderinput" && fileList.length <= 0) {
+      alert("No files to upload! Make sure the folder being uploaded contains at least one file.\n\nNOTE: You can create an empty folder by using the 'Create New Folder' option on the left panel.");
+    } else {
+      let files = this.props.filemgmt.uploadableFiles;
+      for (let i = 0; i < fileList.length; i++) {
+        files.push(fileList[i]);
+      }
+      this.props.updateUploadableFiles(files);
     }
-    this.props.updateUploadableFiles(files);
 
     // Allow selecting same file(s) more than once for upload
     document.getElementById('fileinput').value = null;
@@ -137,7 +141,7 @@ class FileUploadComponent extends Component {
             </Button.Content>
           </Button>
           <input type='file' id='fileinput' style = {{display : 'None'}}
-          onChange={(e) => this.handleFileInputChange(e.target.files)} multiple/>
+          onChange={(e) => this.handleFileInputChange(e.target.files, "fileinput")} multiple/>
         </span>
         <span>
           <Button animated='vertical' color='blue' onClick = {() => {
@@ -151,7 +155,7 @@ class FileUploadComponent extends Component {
             </Button.Content>
           </Button>
           <input type='file' id='folderinput' style = {{display : 'None'}}
-          onChange={(e) => this.handleFileInputChange(e.target.files)} multiple='' webkitdirectory='' mozdirectory='' directory=''/>
+          onChange={(e) => this.handleFileInputChange(e.target.files, "folderinput")} multiple='' webkitdirectory='' mozdirectory='' directory=''/>
         </span>
         <span style={{ float : 'right' }}>
             <Button animated='vertical' color='green' onClick = {this.handleApplyChanges.bind(this)}>


### PR DESCRIPTION
Bug Number: [OP-93](https://project-sunbird.atlassian.net/browse/OP-93)
Issue: Empty folders can't be uploaded
RCA: Browser doesn't allow to upload folders really. The workaround was to upload all files under the selected folder, extract  and create the parent directory from their meta-data and put all the files under the said folder. This doesn't work if there are no files present.
Fix: An alert message pops up if the user tries to upload an empty folder. Besides, there is already the option to create a new folder in case that's what the user wants to achieve.