### PR TITLE
Fixes issue OP-71

### DIFF
--- a/CDN/postpreinstall.sh
+++ b/CDN/postpreinstall.sh
@@ -70,6 +70,10 @@ systemctl restart aria2
 
 reboot_device
 
+# These instructions have been moved after the reboot
+# because this script gets called from within the devmgmt
+# service and once devmgmt got restarted, the script came
+# to a halt and further instructions were never executed
 systemctl enable devmgmt
 systemctl restart devmgmt
 

--- a/CDN/postpreinstall.sh
+++ b/CDN/postpreinstall.sh
@@ -12,7 +12,7 @@ for i in $files_saved
 do
 	 cp $i /tmp
 done
-	
+
 }
 
 restore_files()
@@ -62,9 +62,6 @@ systemctl restart searchserver
 systemctl enable appserver
 systemctl restart appserver
 
-systemctl enable devmgmt
-systemctl restart devmgmt
-
 systemctl enable syncthing
 systemctl restart syncthing
 
@@ -73,8 +70,10 @@ systemctl restart aria2
 
 reboot_device
 
-exit 0
+systemctl enable devmgmt
+systemctl restart devmgmt
 
+exit 0
 }
 
 pre_install()
@@ -90,7 +89,7 @@ if [ "$1" == "-post" ]
 	then
 	post_install
 fi
-	
+
 if [ "$1" == "-pre" ]
 		then
 		pre_install


### PR DESCRIPTION
Bug Number: [OP-71](https://project-sunbird.atlassian.net/browse/OP-71)
Issue: The device doesn't reboot after upgradation process
RCA: Post installation script gets called from within the `devmgmt` service. This script had the instructions to **first** restart the `devmgmt` service (among other services) and **then** reboot the system. This caused the execution of the script to come to a halt before it even reached the reboot command.
Fix: Change the order of execution, i.e. perform reboot before restarting the `devmgmt` service