### PR TITLE
[OP-67] User will be redirected to the dashboard from the login page if already authenticated

### DIFF
--- a/devmgmtui/src/App.js
+++ b/devmgmtui/src/App.js
@@ -36,7 +36,7 @@ class App extends Component {
       <div className="App">
             <BrowserRouter >
                 <div>
-                    <Route exact path={"/"} component={Login} />
+                    <Route exact path={"/"} component={verifyAuth(Login)} />
                     <Route exact path={"/users/edit/:username/:permissions"} component={verifyAuth(EditUser)} />
                     <Route exact path={"/create/user"} component={verifyAuth(CreateUser)} />
                     <Route exact path={"/users"} component={verifyAuth(UserList)} />

--- a/devmgmtui/src/components/VerifyAuthentication.js
+++ b/devmgmtui/src/components/VerifyAuthentication.js
@@ -6,6 +6,11 @@ export default function(ComposedComponent) {
         componentWillMount() {
             if (!this.props.verify.authenticated) {
                 this.props.history.push('/');
+            } else {
+                const { pathname } = this.props.location;
+                if (pathname === "/") {
+                    this.props.history.push("/dashboard");
+                }
             }
         }
 


### PR DESCRIPTION
Bug Number: [OP-67](https://project-sunbird.atlassian.net/browse/OP-67)
Issue: Even when the user name and password is not entered in the log-in page, the user can navigate to any other page by just knowing the URL.
RCA: Even if the user is authenticated, the login page was being displayed when the user visited the respective URL. This caused some misunderstanding and led the user to think they were not logged in even though they were.
Fix: Redirect user to the dashboard when they are visiting the login page if they have already been authenticated 