### PR TITLE
deletion of multiple ecar files leads to system crash fix

### DIFF
--- a/devmgmtui/src/components/filemgmt/FileDisplayComponent.js
+++ b/devmgmtui/src/components/filemgmt/FileDisplayComponent.js
@@ -71,9 +71,19 @@ class FileDisplayComponent extends Component {
   selectAll() {
     let currentDirFiles = this.props.filemgmt.files;
     if (!this.state.allSelected) {
+      if(this.props.filemgmt.currentDir === "/home/admin/diksha/ecar_files/") {
+        this.props.updateSelectedFiles(currentDirFiles.map((item, index) => (item.id + item.ext)));
+      }
+      else {
       this.props.updateSelectedFiles(currentDirFiles.map((item, index) => item.name));
+      }     
     } else if(!this.props.filemgmt.selectedFiles.length) {
-      this.props.updateSelectedFiles(currentDirFiles.map((item, index) => item.name));
+      if (this.props.filemgmt.currentDir === "/home/admin/diksha/ecar_files/") {
+        this.props.updateSelectedFiles(currentDirFiles.map((item, index) => (item.id + item.ext)));
+      }
+      else {
+      this.props.updateSelectedFiles(currentDirFiles.map((item, index) => item.name)); 
+      }   
     } else {
       this.props.updateSelectedFiles([]);
     }

--- a/devmgmtui/src/components/filemgmt/FileUnitComponent.js
+++ b/devmgmtui/src/components/filemgmt/FileUnitComponent.js
@@ -24,7 +24,7 @@ class FileUnitComponent extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selected : (this.props.filemgmt.selectedFiles.indexOf(props.name) >= 0)
+      selected : (this.props.filemgmt.selectedFiles.indexOf(props.name) >= 0 || this.props.filemgmt.selectedFiles.indexOf(props.id + props.ext) >= 0)
     }
     this.toggleSelected = this.toggleSelected.bind(this);
   }
@@ -37,14 +37,19 @@ class FileUnitComponent extends Component {
   }*/
 
   componentWillReceiveProps(newProps, newState) {
-    this.setState({selected : (newProps.filemgmt.selectedFiles.indexOf(this.props.name) >= 0)})
+    this.setState({selected : (newProps.filemgmt.selectedFiles.indexOf(this.props.name) >= 0 || newProps.filemgmt.selectedFiles.indexOf(this.props.id + this.props.ext) >= 0)})
   }
   toggleSelected() {
     let currentlySelectedFiles = this.props.filemgmt.selectedFiles;
     if (this.state.selected) {
       currentlySelectedFiles.splice(currentlySelectedFiles.indexOf(this.props.name), 1);
     } else {
+      if(this.props.filemgmt.currentDir === "/home/admin/diksha/ecar_files/") {
+      currentlySelectedFiles.push(this.props.id + this.props.ext);
+      }
+      else {
       currentlySelectedFiles.push(this.props.name);
+      }
     }
     this.setState({selected : !this.state.selected});
     this.props.updateSelectedFiles(currentlySelectedFiles);


### PR DESCRIPTION
Bug No. - OP-90
Issue - inside the ecar_files folder, when files are deleted by doing "Select All" or individually selecting files and clicking on "Delete Selected" button leads to system crash
RCA - while deleting files from ecar_files, name was being used to delete instead of id, that led to system crash
Fix - pushed id instead of name into the selected list when deleting files from ecar_files folder
Addresses issue: https://project-sunbird.atlassian.net/projects/OP/issues/OP-90