### PR TITLE
fix load content doesnt work in case of fail download or corrupt ecar file

### DIFF
--- a/filesdk/index.js
+++ b/filesdk/index.js
@@ -78,15 +78,19 @@ let extractZip = (source, destination) => {
     return extractWithUnzipStream(source, destination);
 }
 let extractWithUnzipStream = (src, dest) => {
-	let defer = q.defer();
-
-	fs.createReadStream(src)
+        let defer = q.defer();
+        fs.createReadStream(src)
 		.pipe(unzip.Extract({ path: dest }))
 		.on('close', (err) => {
-			if (err) defer.reject(err);
-			else defer.resolve('Done!!!');
-        });
-
+			if (err) {
+			    defer.reject(err);
+			}	
+			else {
+                defer.resolve('Done!!!');
+			}	
+        	}).on('error', (err) => {
+			    defer.reject(err);
+		});	
 	return defer.promise;
 }
 let extractTar = (source, destination) => {


### PR DESCRIPTION
Bug no. - OP-82,
Issue - when multiple files are downloaded or uploaded and if one or many files among those downloaded or uploaded are corrupt or there is a case of fail download , rest of ecar files that were valid should get loaded into plugin.
RCA - unzip-stream library was used to unzip ecar files and it was not handling the case when ecar files couldn't be extracted i.e. when there is an error situation
Fix - added the condition to handle the error event
Addresses issue - https://project-sunbird.atlassian.net/browse/OP-82