### PR TITLE
Fixes issue OP-60

### DIFF
--- a/devmgmtV2/controllers/dashboard.controller.js
+++ b/devmgmtV2/controllers/dashboard.controller.js
@@ -34,8 +34,8 @@ let getInternetStatus = (req, res) => {
 
 let getLastRefresh = (req, res) => {
     let meta = path.join(config.FS_ROOT, '.meta');
-    fs.readFile(meta, 'utf-8', (err,data)=>{
-        res.send({data});
+    fs.readFile(meta, 'utf-8', (err, data = "Not refreshed yet") => {
+        res.send({ data });
     })
 }
 


### PR DESCRIPTION
Bug Number: [OP-60](https://project-sunbird.atlassian.net/browse/OP-60)
Issue: Last content refresh keeps loading instead of showing proper message in case no content was uploaded/refreshed
RCA: Last refresh timestamp is stored in a file called `.meta`. In the case where refresh/update never happened, the file wouldn't be created at all and `undefined` would be returned from the backend. The frontend upon receiving this data would perform a check to ensure that there's some data present to display. If no data was present, it meant the API called had not been resolved and a spinner was rendered. Now, on receiving `undefined`, though the API call was resolved the condition to check data presence resulted in `false` because `undefined` is falsy. This caused the spinner to be rendered.
Fix: Return a proper message from the backend instead of sending `undefined` in case no `.meta` file exists.