### PR TITLE
Limited search results on diksha app fix

### DIFF
--- a/searchsdk/index.js
+++ b/searchsdk/index.js
@@ -225,7 +225,7 @@ let search = (params) => {
     let options = {
         url : `${SEARCH_SERVER}/${INDEX_BASE_URL}/${indexName}/_search`,
         method : 'POST',
-        body : JSON.stringify({"query" : {"query" : searchString}})
+        body : JSON.stringify({"query" : {"query" : searchString}, "size" : 1000})
     }
     request(options, (err, res, body) => {
         if (err) {


### PR DESCRIPTION
Bug No- OP-117
Issue: While searching for something on the diksha app, the results that were given by app are only limited to 10 and even if the search matches to more than 10 files , it will show only 10 files/results.
RCA:  Search results were limited to 10 by default 
Fix: added a size key to increase the size to 1000.
Addresses issue: https://project-sunbird.atlassian.net/browse/OP-117