### PR TITLE
Bug No: OP-26

### DIFF
--- a/CDN/postpreinstall.sh
+++ b/CDN/postpreinstall.sh
@@ -52,6 +52,9 @@ restore_files
 mkdir -p /opt/searchEngine/bleveDbDir/
 mkdir -p /home/admin/GoK/
 
+#Set System time-zone
+sudo timedatectl set-timezone Asia/Kolkata
+
 # Install aria2 and clean up the deb files used
 install_aria2
 remove_aria2_deb


### PR DESCRIPTION
    Issue: Displayed time is wrong in dashboard page
    RCA: The System timezone was set to Etc/UTC and the same time was fetched for displaying "Last Content Refresh".
    Fix: Changed the timezone to Asia/Kolkata.