### PR TITLE
Prevent services from getting restarted after upgrade

### DIFF
--- a/CDN/postpreinstall.sh
+++ b/CDN/postpreinstall.sh
@@ -57,16 +57,12 @@ install_aria2
 remove_aria2_deb
 
 systemctl enable searchserver
-systemctl restart searchserver
 
 systemctl enable appserver
-systemctl restart appserver
 
 systemctl enable syncthing
-systemctl restart syncthing
 
 systemctl enable aria2
-systemctl restart aria2
 
 reboot_device
 


### PR DESCRIPTION
Since service will be restarted automatically after reboot that happens after every upgrade, there is no need to restart them after every upgrade
Addresses issue: https://project-sunbird.atlassian.net/browse/OP-124