### PR TITLE
 Bug No:OP-119

### DIFF
--- a/CDN/postpreinstall.sh
+++ b/CDN/postpreinstall.sh
@@ -69,16 +69,16 @@ systemctl enable aria2
 systemctl restart aria2
 
 #Optimize the system
-sudo rm -rf /var/log/daemon.log
+rm -rf /var/log/daemon.log
 ln -s /dev/null /var/log/daemon.log
 
-sudo rm -rf /var/log/dnsmasq.log
+rm -rf /var/log/dnsmasq.log
 ln -s /dev/null /var/log/dnsmasq.log
 
-sudo rm -rf /var/log/syslog
+rm -rf /var/log/syslog
 ln -s /dev/null /var/log/syslog
 
-sudo update-rc.d dphys-swapfile remove
+update-rc.d dphys-swapfile remove
 
 reboot_device
 

--- a/CDN/postpreinstall.sh
+++ b/CDN/postpreinstall.sh
@@ -68,6 +68,18 @@ systemctl restart syncthing
 systemctl enable aria2
 systemctl restart aria2
 
+#Optimize the system
+sudo rm -rf /var/log/daemon.log
+ln -s /dev/null /var/log/daemon.log
+
+sudo rm -rf /var/log/dnsmasq.log
+ln -s /dev/null /var/log/dnsmasq.log
+
+sudo rm -rf /var/log/syslog
+ln -s /dev/null /var/log/syslog
+
+sudo update-rc.d dphys-swapfile remove
+
 reboot_device
 
 # These instructions have been moved after the reboot


### PR DESCRIPTION
    Issue: When a large number of files are uploaded into the OpenRAP, the device slows down.
    RCA: Log files start accumulating and their size increases.Even the Swap memory was used considerably.
    FIx: Log files are linked with /dev/null and the swap memory is cleared.