### PR TITLE
[OP-136] Displaying Syncthing ID on the dashboard

### DIFF
--- a/devmgmtV2/controllers/dashboard.controller.js
+++ b/devmgmtV2/controllers/dashboard.controller.js
@@ -103,7 +103,7 @@ let getDeviceID = (req,res) => {
     let responseData = {
         retrieveSuccessful : true,
         deviceID : undefined,
-        msg : 'Successfully retrieved Mac address'
+        msg : 'Successfully retrieved device ID'
     }
 
     selectFields({dbName : 'device_mgmt', tableName : 'device', columns : ["dev_id"]})
@@ -117,6 +117,29 @@ let getDeviceID = (req,res) => {
         });
 }
 
+let getSyncthingID = (req, res) => {
+    let responseData = {
+        retrieveSuccessful: true,
+        syncthingID: undefined,
+        msg: 'Successfully retrieved syncthing ID'
+    }
+
+    const cmd = 'sudo /opt/opencdn/CDN/syncthing -device-id';
+
+    exec(cmd, { shell: '/bin/bash' }, (err, stdout, stderr) => {
+        if (err) {
+            console.log("Error occurred while fetching syncthing ID\n", JSON.stringify({ err, stderr }, null, 4));
+
+            responseData.retrieveSuccessful = false;
+            responseData.msg = err;
+        } else {
+            responseData.syncthingID = stdout.trim();
+        }
+
+        res.status(200).json(responseData);
+    });
+}
+
 module.exports = {
     getInternetStatus,
     getLastRefresh,
@@ -125,5 +148,6 @@ module.exports = {
     getSystemSpace,
     getSystemCpu,
     getSystemVersion,
-    getDeviceID
+    getDeviceID,
+    getSyncthingID
 }

--- a/devmgmtV2/routes/dashboard.routes.js
+++ b/devmgmtV2/routes/dashboard.routes.js
@@ -8,7 +8,8 @@ let {
     getSystemSpace,
     getSystemCpu,
     getSystemVersion,
-    getDeviceID
+    getDeviceID,
+    getSyncthingID
 } = require("../controllers/dashboard.controller")
 
 const { saveTelemetryData } = require('../middlewares/telemetry.middleware.js');
@@ -22,4 +23,5 @@ module.exports = app => {
     app.get("/dashboard/system/cpu", getSystemCpu);
     app.get("/dashboard/system/version", getSystemVersion);
     app.get("/dashboard/system/deviceID", getDeviceID);
+    app.get("/dashboard/system/syncthingID", getSyncthingID);
 }

--- a/devmgmtui/src/actions/dashboard.js
+++ b/devmgmtui/src/actions/dashboard.js
@@ -74,4 +74,12 @@ export const fetchSystemData = () => (dispatch) => {
         .catch((e) => {
             console.log(e);
         })
+
+    axios.get(`${BASE_URL}/dashboard/system/syncthingID`)
+        .then((response) => {
+            dispatch({type: 'SYNCTHING_ID_FETCH', payload: response.data.syncthingID})
+        })
+        .catch((e) => {
+            console.log(e);
+        })
 }

--- a/devmgmtui/src/components/dashboard/SysInfo.js
+++ b/devmgmtui/src/components/dashboard/SysInfo.js
@@ -79,6 +79,7 @@ class SysInfo extends Component {
             :
             false;
         let deviceID = this.props.dashboard.deviceID;
+        let syncthingID = this.props.dashboard.syncthingID;
 
         const secondsToDDHHMMSS = (totalSeconds) => {
             let days    = Math.floor(totalSeconds / (3600 * 24));
@@ -133,7 +134,11 @@ class SysInfo extends Component {
                         <Grid.Column>
                             {this.renderMessage('users', 'Number of Users connected', usersConnected)}
                         </Grid.Column>
-                        <Grid.Column/>
+
+                        <Grid.Column>
+                            {this.renderMessage('id badge', 'Syncthing ID', syncthingID)}
+                        </Grid.Column>
+                        
                         <Grid.Column/>
                     </Grid.Row>
                 </Grid>

--- a/devmgmtui/src/components/dashboard/SysInfo.js
+++ b/devmgmtui/src/components/dashboard/SysInfo.js
@@ -138,7 +138,7 @@ class SysInfo extends Component {
                         <Grid.Column>
                             {this.renderMessage('id badge', 'Syncthing ID', syncthingID)}
                         </Grid.Column>
-                        
+
                         <Grid.Column/>
                     </Grid.Row>
                 </Grid>

--- a/devmgmtui/src/reducers/dashboard.js
+++ b/devmgmtui/src/reducers/dashboard.js
@@ -18,6 +18,8 @@ export default function (state={}, action) {
             return {...state, version: action.payload};
         case 'DEVICEID_FETCH':
             return {...state, deviceID: action.payload};
+        case 'SYNCTHING_ID_FETCH':
+            return {...state, syncthingID: action.payload};
         default:
             return state;
     }


### PR DESCRIPTION
Bug Number: [OP-136](https://project-sunbird.atlassian.net/browse/OP-136)
Issue: Syncthing ID should be displayed on the dashboard
Description: Syncthing ID should be displayed on the dashboard so that the user can map it to the prompt on OpenRAP cloud's Syncthing prompt during device registration.
Fix: Add syncthing widget to the dashboard
