### PR TITLE
Bug No: OP-114

### DIFF
--- a/devmgmtV2/controllers/filemgmt.controller.js
+++ b/devmgmtV2/controllers/filemgmt.controller.js
@@ -289,7 +289,7 @@ let deleteFileFromDisk = (req, res) => {
   if (ext === '.ecar') {
     cmd = `rm -rf ${file}* ${json_dir}* ${xcontent}*`;
   } else {
-    if(!(dir.startsWith('/home/admin/diksha'))){
+    if((dir.startsWith('/home/admin')) && (!(dir.startsWith('/home/admin/diksha')))){
       fileToDelete = fileToDelete.replace(/\W/g,"\\$&");
       cmd = `rm -rf ${fileToDelete}`;
     }else {

--- a/devmgmtV2/controllers/filemgmt.controller.js
+++ b/devmgmtV2/controllers/filemgmt.controller.js
@@ -289,6 +289,7 @@ let deleteFileFromDisk = (req, res) => {
   if (ext === '.ecar') {
     cmd = `rm -rf ${file}* ${json_dir}* ${xcontent}*`;
   } else {
+    // deletion of files outside the "/home/admin" dir and inside the "/home/admin/diksha" dir has been restricted.
     if((dir.startsWith('/home/admin')) && (!(dir.startsWith('/home/admin/diksha')))){
       fileToDelete = fileToDelete.replace(/\W/g,"\\$&");
       cmd = `rm -rf ${fileToDelete}`;

--- a/devmgmtV2/controllers/upgrade.controller.js
+++ b/devmgmtV2/controllers/upgrade.controller.js
@@ -20,8 +20,10 @@ let writeUpdateFile = (req, res) => {
         console.log(`stdout: ${stdout}`);
         console.log(`stderr: ${stderr}`);
         res.status(200).json({success : true});
-        console.log("Reboot starts...")
-        exec('/sbin/reboot');
+        setTimeout(() => {
+          exec('/sbin/reboot');
+        }, 10000);
+        
         }
       })
     }

--- a/devmgmtui/src/components/upgrade/UpgradeDisplayComponent.js
+++ b/devmgmtui/src/components/upgrade/UpgradeDisplayComponent.js
@@ -53,6 +53,7 @@ class UpgradeDisplayComponent extends Component {
         } else {
           alert('Successfully Upgraded!.Rebooting Now...');
           this.setState({fileUploadedStatus:"DONE"});
+          window.location.reload(true);
         }
       });
     }


### PR DESCRIPTION
Issue: When upgrading version from 2.20.x to 2.21.x, deletion of ecar files in ecar_files folder leads to system crash
RCA : After the Upgrade process, the page was not refreshed and hence new UI changes were not reflected on the new build(2.21.x).
Since the "deletion of ecar files in ecar_files folder leads to system crash" bug is fixed on the front end, it is not reflected due to the above said reason.
Fix: 1) After a successful upgrade process the entire window is reloaded and then device gets rebooted (delayed by 10seconds)
     2) Deletion operation has been restricted within the '/home/admin' directory.