### PR TITLE
Bug No: OP-139

### DIFF
--- a/devmgmtV2/controllers/filemgmt.controller.js
+++ b/devmgmtV2/controllers/filemgmt.controller.js
@@ -183,7 +183,7 @@ let classify = (dir, file) => {
       if (ext === '.ecar' && isEcarDir(dir)) {
         const db = getEcarDb(dir);
 
-        getEcarNameForId(file, db)
+        getEcarNameForId(file+'.json', db) //Name of the file will be present inside the ".json" file(meta data)
           .then(ecarName => {
             const id = name.substring(0, name.lastIndexOf('_'));
 


### PR DESCRIPTION
Issue: Ecar file names are not displayed
RCA: The name of an ecar file is fetched from .json file with the help of its id.
Instead of passing the id to a .json file, it was passed to .ecar file and hence the file names were not fetched.
Fix: The id is appended with .json as extension so that it correctly identifies the proper json file and fetches the name.